### PR TITLE
Fixes to OreoLED_PX4

### DIFF
--- a/libraries/AP_Notify/OreoLED_PX4.cpp
+++ b/libraries/AP_Notify/OreoLED_PX4.cpp
@@ -35,10 +35,10 @@
 #define OREOLED_BACKRIGHT               1       // back right led instance number
 #define OREOLED_FRONTRIGHT              2       // front right led instance number
 #define OREOLED_FRONTLEFT               3       // front left led instance number
-#define PERIOD_SLOW                     8195    // Slow flash rate
-#define PERIOD_FAST                     62465   // Fast flash rate
-#define PERIOD_SUPER                    38400   // Super fast rate
-#define PO_ALTERNATE                    46080   // 180 degree Phase Offset
+#define PERIOD_SLOW                     800     // Slow flash rate
+#define PERIOD_FAST                     500     // Fast flash rate
+#define PERIOD_SUPER                    150     // Super fast rate
+#define PO_ALTERNATE                    180     // 180 degree Phase Offset
 
 extern const AP_HAL::HAL& hal;
 
@@ -676,4 +676,67 @@ void OreoLED_PX4::handle_led_control(mavlink_message_t *msg)
     }
     _pattern_override = packet.pattern;
 }
+
+OreoLED_PX4::oreo_state::oreo_state() {
+    clear_state();
+}
+
+void OreoLED_PX4::oreo_state::clear_state() {
+    mode = OREOLED_MODE_NONE;
+    pattern = OREOLED_PATTERN_OFF;
+    macro = OREOLED_PARAM_MACRO_RESET;
+    red = 0;
+    green = 0;
+    blue = 0;
+    amplitude_red = 0;
+    amplitude_green = 0;
+    amplitude_blue = 0;
+    period = 0;
+    repeat = 0;
+    phase_offset = 0;
+}
+
+void OreoLED_PX4::oreo_state::send_sync() {
+    clear_state();
+    mode = OREOLED_MODE_SYNC;
+}
+
+void OreoLED_PX4::oreo_state::set_macro(oreoled_macro new_macro) {
+    clear_state();
+    mode = OREOLED_MODE_MACRO;
+    macro = new_macro;
+}
+
+void OreoLED_PX4::oreo_state::set_rgb(enum oreoled_pattern new_pattern, uint8_t new_red, uint8_t new_green, uint8_t new_blue) {
+    clear_state();
+    mode = OREOLED_MODE_RGB;
+    pattern = new_pattern;
+    red = new_red;
+    green = new_green;
+    blue = new_blue;
+}
+
+void OreoLED_PX4::oreo_state::set_rgb(enum oreoled_pattern new_pattern, uint8_t new_red, uint8_t new_green,
+        uint8_t new_blue, uint8_t new_amplitude_red, uint8_t new_amplitude_green, uint8_t new_amplitude_blue,
+        uint16_t new_period, uint16_t new_phase_offset) {
+    clear_state();
+    mode = OREOLED_MODE_RGB_EXTENDED;
+    pattern = new_pattern;
+    red = new_red;
+    green = new_green;
+    blue = new_blue;
+    amplitude_red = new_amplitude_red;
+    amplitude_green = new_amplitude_green;
+    amplitude_blue = new_amplitude_blue;
+    period = new_period;
+    phase_offset = new_phase_offset;
+}
+
+bool OreoLED_PX4::oreo_state::operator==(const OreoLED_PX4::oreo_state &os) {
+   return ((os.mode==mode) && (os.pattern==pattern) && (os.macro==macro) && (os.red==red) && (os.green==green) && (os.blue==blue)
+           && (os.amplitude_red==amplitude_red) && (os.amplitude_green==amplitude_green) && (os.amplitude_blue==amplitude_blue)
+           && (os.period==period) && (os.repeat==repeat) && (os.phase_offset==phase_offset));
+}
+
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_PX4
+

--- a/libraries/AP_Notify/OreoLED_PX4.cpp
+++ b/libraries/AP_Notify/OreoLED_PX4.cpp
@@ -537,12 +537,14 @@ void OreoLED_PX4::update_timer(void)
                     cmd.buff[10] = _state_desired[i].amplitude_green;
                     cmd.buff[11] = OREOLED_PARAM_AMPLITUDE_BLUE;
                     cmd.buff[12] = _state_desired[i].amplitude_blue;
+                    // Note: The Oreo LED controller expects to receive uint16 values
+                    // in little endian order
                     cmd.buff[13] = OREOLED_PARAM_PERIOD;
-                    cmd.buff[14] = (_state_desired[i].period & 0x00FF);
-                    cmd.buff[15] = (_state_desired[i].period & 0xFF00) >> 8;
+                    cmd.buff[14] = (_state_desired[i].period & 0xFF00) >> 8;
+                    cmd.buff[15] = (_state_desired[i].period & 0x00FF);
                     cmd.buff[16] = OREOLED_PARAM_PHASEOFFSET;
-                    cmd.buff[17] = (_state_desired[i].phase_offset & 0x00FF);
-                    cmd.buff[18] = (_state_desired[i].phase_offset & 0xFF00) >> 8;
+                    cmd.buff[17] = (_state_desired[i].phase_offset & 0xFF00) >> 8;
+                    cmd.buff[18] = (_state_desired[i].phase_offset & 0x00FF);
                     cmd.num_bytes = 19;
                     ioctl(_oreoled_fd, OREOLED_SEND_BYTES, (unsigned long)&cmd);
                     }
@@ -646,12 +648,14 @@ void OreoLED_PX4::handle_led_control(mavlink_message_t *msg)
             // convert the first byte after the command to a oreoled_pattern
             oreoled_pattern pattern = (oreoled_pattern)packet.custom_bytes[CUSTOM_HEADER_LENGTH];
 
+            // uint16_t values are stored in custom_bytes in little endian order
+            // assume the flight controller is little endian when decoding values
             uint16_t period =
-                    (0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 7]) |
-                    ((0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 8]) << 8);
+                    ((0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 7]) << 8) |
+                    (0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 8]);
             uint16_t phase_offset =
-                    (0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 9]) |
-                    ((0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 10]) << 8);
+                    ((0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 9]) << 8) |
+                    (0x00FF & (uint16_t)packet.custom_bytes[CUSTOM_HEADER_LENGTH + 10]);
 
             // call the set_rgb function, using the rest of the bytes as the RGB values
             set_rgb(packet.instance, pattern, packet.custom_bytes[CUSTOM_HEADER_LENGTH + 1], packet.custom_bytes[CUSTOM_HEADER_LENGTH + 2],

--- a/libraries/AP_Notify/OreoLED_PX4.h
+++ b/libraries/AP_Notify/OreoLED_PX4.h
@@ -117,67 +117,21 @@ private:
         int8_t repeat;
         uint16_t phase_offset;
 
-        inline oreo_state() {
-            clear_state();
-        }
+        oreo_state();
 
-        inline void clear_state() {
-            mode = OREOLED_MODE_NONE;
-            pattern = OREOLED_PATTERN_OFF;
-            macro = OREOLED_PARAM_MACRO_RESET;
-            red = 0;
-            green = 0;
-            blue = 0;
-            amplitude_red = 0;
-            amplitude_green = 0;
-            amplitude_blue = 0;
-            period = 0;
-            repeat = 0;
-            phase_offset = 0;
-        }
+        void clear_state();
 
-        inline void send_sync() {
-            clear_state();
-            mode = OREOLED_MODE_SYNC;
-        }
+        void send_sync();
 
-        inline void set_macro(oreoled_macro new_macro) {
-            clear_state();
-            mode = OREOLED_MODE_MACRO;
-            macro = new_macro;
-        }
+        void set_macro(oreoled_macro new_macro);
 
-        inline void set_rgb(enum oreoled_pattern new_pattern, uint8_t new_red, uint8_t new_green, uint8_t new_blue) {
-            clear_state();
-            mode = OREOLED_MODE_RGB;
-            pattern = new_pattern;
-            red = new_red;
-            green = new_green;
-            blue = new_blue;
-        }
+        void set_rgb(enum oreoled_pattern new_pattern, uint8_t new_red, uint8_t new_green, uint8_t new_blue);
 
-        inline void set_rgb(enum oreoled_pattern new_pattern, uint8_t new_red, uint8_t new_green,
+        void set_rgb(enum oreoled_pattern new_pattern, uint8_t new_red, uint8_t new_green,
                 uint8_t new_blue, uint8_t new_amplitude_red, uint8_t new_amplitude_green, uint8_t new_amplitude_blue,
-                uint16_t new_period, uint16_t new_phase_offset) {
-            clear_state();
-            mode = OREOLED_MODE_RGB_EXTENDED;
-            pattern = new_pattern;
-            red = new_red;
-            green = new_green;
-            blue = new_blue;
-            amplitude_red = new_amplitude_red;
-            amplitude_green = new_amplitude_green;
-            amplitude_blue = new_amplitude_blue;
-            period = new_period;
-            phase_offset = new_phase_offset;
-        }
+                uint16_t new_period, uint16_t new_phase_offset);
 
-        // operator==
-        inline bool operator==(const oreo_state &os) {
-           return ((os.mode==mode) && (os.pattern==pattern) && (os.macro==macro) && (os.red==red) && (os.green==green) && (os.blue==blue)
-        		   && (os.amplitude_red==amplitude_red) && (os.amplitude_green==amplitude_green) && (os.amplitude_blue==amplitude_blue)
-        		   && (os.period==period) && (os.repeat==repeat) && (os.phase_offset==phase_offset));
-        }
+        bool operator==(const oreo_state &os);
     };
 
     // private members


### PR DESCRIPTION
A couple of commits to fix the byte ordering on the uint16 values and to remove the inlined functions in the header.